### PR TITLE
Fix unsafe object instantiation check - rector

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $class = $_GET['itemtype'];
 
 $object = new $class(); // unsafe
 
-if (is_a($class, CommonDBTM::class, true)) {
+if (!$class instanceof CommonITILObject) {
     $object = new $class(); // safe
 }
 ```


### PR DESCRIPTION
rector now transforms `is_a(...)` in `!$class instanceof \CommonITILObject`

So copy/paste from here won't generate incorrect code regarding rector rules.