### PR TITLE
Fix unexpected `CommonDBTM::can()` `$input` param-out type

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -11,6 +11,10 @@ parameters:
 
 services:
     -
+        class: PHPStanGlpi\Analyser\CommonDBTMCanInputParamOutTypeResolver
+        tags:
+            - phpstan.methodParameterOutTypeExtension
+    -
         class: PHPStanGlpi\Analyser\GlobalTypeResolver
         tags:
             - phpstan.broker.expressionTypeResolverExtension

--- a/src/Analyser/CommonDBTMCanInputParamOutTypeResolver.php
+++ b/src/Analyser/CommonDBTMCanInputParamOutTypeResolver.php
@@ -17,7 +17,7 @@ class CommonDBTMCanInputParamOutTypeResolver implements MethodParameterOutTypeEx
         MethodReflection $methodReflection,
         ParameterReflection $parameter
     ): bool {
-        return $methodReflection->getDeclaringClass()->getName() === \CommonDBTM::class // @phpstan-ignore class.notFound
+        return $methodReflection->getDeclaringClass()->getName() === \CommonDBTM::class
             && \in_array($methodReflection->getName(), ['can', 'check'], true)
             && $parameter->getName() === 'input';
     }
@@ -38,7 +38,7 @@ class CommonDBTMCanInputParamOutTypeResolver implements MethodParameterOutTypeEx
         // Returning its know type prevents PHPStan to consider it can be changed from `array` to `null`
         // inside the method.
         //
-        // The `CommonDBTM::check()` is a proxy to `CommonDBTM::can()` and therefore should act the same way.
+        // `CommonDBTM::check()` is a proxy to `CommonDBTM::can()` and therefore should behave the same way.
         return $scope->getType($inputArg->value);
     }
 }

--- a/src/Analyser/CommonDBTMCanInputParamOutTypeResolver.php
+++ b/src/Analyser/CommonDBTMCanInputParamOutTypeResolver.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPStanGlpi\Analyser;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Type\MethodParameterOutTypeExtension;
+use PHPStan\Type\Type;
+
+class CommonDBTMCanInputParamOutTypeResolver implements MethodParameterOutTypeExtension
+{
+    public function isMethodSupported(
+        MethodReflection $methodReflection,
+        ParameterReflection $parameter
+    ): bool {
+        return $methodReflection->getDeclaringClass()->getName() === \CommonDBTM::class // @phpstan-ignore class.notFound
+            && \in_array($methodReflection->getName(), ['can', 'check'], true)
+            && $parameter->getName() === 'input';
+    }
+
+    public function getParameterOutTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        ParameterReflection $parameter,
+        Scope $scope
+    ): ?Type {
+        $inputArg = $methodCall->getArg('input', 2);
+
+        if ($inputArg === null) {
+            return null;
+        }
+
+        // The `CommonDBTM::can()` method always preserve the `$input` parameter type.
+        // Returning its know type prevents PHPStan to consider it can be changed from `array` to `null`
+        // inside the method.
+        //
+        // The `CommonDBTM::check()` is a proxy to `CommonDBTM::can()` and therefore should act the same way.
+        return $scope->getType($inputArg->value);
+    }
+}

--- a/tests/Analyser/CommonDBTMCanInputParamOutTypeResolverTest.php
+++ b/tests/Analyser/CommonDBTMCanInputParamOutTypeResolverTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPStanGlpi\Tests\Analyser;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+
+class CommonDBTMCanInputParamOutTypeResolverTest extends TypeInferenceTestCase
+{
+    /**
+     * @phpstan-ignore missingType.iterableValue
+     */
+    public static function dataFileAsserts(): iterable
+    {
+        yield from self::gatherAssertTypes(__DIR__ . '/../data/CommonDBTMCanInputParamOutTypeResolver/param-out.php');
+    }
+
+    /**
+     * @param mixed ...$args
+     * @dataProvider dataFileAsserts
+     */
+    public function testFileAsserts(
+        string $assertType,
+        string $file,
+        ...$args
+    ): void {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/../data/CommonDBTMCanInputParamOutTypeResolver/extension.neon',
+        ];
+    }
+}

--- a/tests/Analyser/GlobalTypeResolverForGlpi10Test.php
+++ b/tests/Analyser/GlobalTypeResolverForGlpi10Test.php
@@ -34,9 +34,8 @@ class GlobalTypeResolverForGlpi10Test extends TypeInferenceTestCase
     public static function getAdditionalConfigFiles(): array
     {
         return [
-            __DIR__ . '/../../extension.neon',
+            __DIR__ . '/../data/GlobalTypeResolver/extension.neon',
             __DIR__ . '/../data/glpi-10.0.x.neon',
-            __DIR__ . '/../data/GlobalTypeResolver/glpi-path.neon',
         ];
     }
 }

--- a/tests/Analyser/GlobalTypeResolverForGlpi11Test.php
+++ b/tests/Analyser/GlobalTypeResolverForGlpi11Test.php
@@ -34,9 +34,8 @@ class GlobalTypeResolverForGlpi11Test extends TypeInferenceTestCase
     public static function getAdditionalConfigFiles(): array
     {
         return [
-            __DIR__ . '/../../extension.neon',
+            __DIR__ . '/../data/GlobalTypeResolver/extension.neon',
             __DIR__ . '/../data/glpi-11.0.x.neon',
-            __DIR__ . '/../data/GlobalTypeResolver/glpi-path.neon',
         ];
     }
 }

--- a/tests/data/CommonDBTMCanInputParamOutTypeResolver/extension.neon
+++ b/tests/data/CommonDBTMCanInputParamOutTypeResolver/extension.neon
@@ -1,0 +1,5 @@
+services:
+    -
+        class: PHPStanGlpi\Analyser\CommonDBTMCanInputParamOutTypeResolver
+        tags:
+            - phpstan.methodParameterOutTypeExtension

--- a/tests/data/CommonDBTMCanInputParamOutTypeResolver/param-out.php
+++ b/tests/data/CommonDBTMCanInputParamOutTypeResolver/param-out.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use function PHPStan\Testing\assertType;
+
+// PHPStan will use the extension only if the signature indicates the param is passed by reference.
+// It requires this stub to be declared.
+class CommonDBTM {
+    public function can($ID, int $right, ?array &$input = null): bool
+    { }
+
+    public function check($ID, int $right, ?array &$input = null): void
+    { }
+}
+
+$object = new class extends CommonDBTM {
+
+};
+
+// $input not explicitely typed and therefore considered as mixed.
+// We cannot guess its type, so its types should remain mixed.
+$object->can(-1, CREATE, $input1);
+assertType('mixed', $input1);
+
+$object->check(-1, CREATE, $input2);
+assertType('mixed', $input2);
+
+// $input declared with a null value.
+// The method will not alter it, it remains null.
+$input1 = null;
+$object->can(-1, CREATE, $input1);
+assertType('null', $input1);
+
+$input2 = null;
+$object->check(-1, CREATE, $input2);
+assertType('null', $input2);
+
+// $input declared with an array value.
+// The method may add entries to the variable, but it will always remain an array.
+$input1 = $_POST;
+$object->can(-1, CREATE, $input1);
+assertType('array<mixed>', $input1);
+
+$input2 = $_POST;
+$object->check(-1, CREATE, $input2);
+assertType('array<mixed>', $input2);

--- a/tests/data/GlobalTypeResolver/extension.neon
+++ b/tests/data/GlobalTypeResolver/extension.neon
@@ -1,0 +1,24 @@
+parametersSchema:
+    glpi: structure([
+        glpiPath: schema(string(), nullable()),
+        glpiVersion: schema(string(), nullable())
+    ])
+
+parameters:
+    glpi:
+        glpiPath: %rootDir%/../../../tests/data/GlobalTypeResolver
+        glpiVersion: null
+
+services:
+    -
+        class: PHPStanGlpi\Analyser\GlobalTypeResolver
+        tags:
+            - phpstan.broker.expressionTypeResolverExtension
+    -
+        class: PHPStanGlpi\Services\GlpiPathResolver
+        arguments:
+            path: %glpi.glpiPath%
+    -
+        class: PHPStanGlpi\Services\GlpiVersionResolver
+        arguments:
+            version: %glpi.glpiVersion%

--- a/tests/data/GlobalTypeResolver/glpi-path.neon
+++ b/tests/data/GlobalTypeResolver/glpi-path.neon
@@ -1,3 +1,0 @@
-parameters:
-    glpi:
-        glpiPath: %rootDir%/../../../tests/data/GlobalTypeResolver


### PR DESCRIPTION
When a parameter is passed by reference, PHPStan assumes that its type can be changed inside the called method to any type allowed by the signature.

Our `CommonDBTM::can()` and `CommonDBTM::check()` methods have a `?array &$input = null`. PHPStan therefore consider that the `$input` variable can be changed to either null or an array inside the method. For instance, an error is detected in the following code:
```php
if ($item->can(-1, CREATE, $_POST)) {
    $name = $_POST['name']; // Offset 'name' might not exist on array|null. (offsetAccess.notFound)
}
```

But the reality is these methods always preserve the passed type. With the proposed `CommonDBTMCanInputParamOutTypeResolver` extension, we will indicate that the type is preserved during the method execution. On the 11.0/bugfixes branch, it fixes 179 errors.