### PR TITLE
Missing $ escaping for PWD in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PHP = docker compose run --rm app
+PHP = docker compose run --remove-orphans --rm app
 
 # Helper variables
 _TITLE := "\033[32m[%s]\033[0m %s\n" # Green text
@@ -17,7 +17,7 @@ help: ## Show this help message
 ## —— Dependencies —————————————————————————————————————————————————————————————————————————————————
 composer: ## Run a composer command, e.g.: make composer c='require org/package'
 	@$(eval c ?=)
-	docker run --rm --interactive --tty --volume $PWD:/app --user $(id -u):$(id -g) --workdir /app composer $(c)
+	docker run --rm --interactive --tty --volume $$PWD:/app --user $(id -u):$(id -g) --workdir /app composer $(c)
 .PHONY: composer
 
 ## —— Code analysis ————————————————————————————————————————————————————————————————————————————————


### PR DESCRIPTION
Running the `make composer c=install` would fail due to missing $ escaping for PWD

<img width="1058" height="212" alt="image" src="https://github.com/user-attachments/assets/0afeadb9-82e0-4a48-848f-021ffde15cda" />
