### PR TITLE
Rule to check hardcoded rightnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,20 @@ Due to a PHP bug (see https://bugs.php.net/bug.php?id=81451), the usage of the `
 define the response code, may produce unexpected results, depending on the server environment.
 Therefore, its usage is discouraged.
 
+### `ForbidHardCodedRightNameRule`
+
+> Since GLPI 12.0.
+
+In GLPI 12.0, right names are no longer plain strings but are defined as a static property `$rightname` on each item class.
+Passing a hardcoded string as the first argument (`module`) of `Session::checkRight()`, `Session::checkRightsOr()`,
+`Session::haveRight()`, `Session::haveRightsAnd()`, or `Session::haveRightsOr()` is therefore an error.
+
+```php
+Session::checkRight('computer', READ); // wrong
+
+Session::checkRight(Computer::$rightname, READ); // correct
+```
+
 ### `MissingGlobalVarTypeRule`
 
 > Since GLPI 10.0.

--- a/README.md
+++ b/README.md
@@ -117,9 +117,8 @@ Therefore, its usage is discouraged.
 
 > Since GLPI 12.0.
 
-In GLPI 12.0, right names are no longer plain strings but are defined as a static property `$rightname` on each item class.
-Passing a hardcoded string as the first argument (`module`) of `Session::checkRight()`, `Session::checkRightsOr()`,
-`Session::haveRight()`, `Session::haveRightsAnd()`, or `Session::haveRightsOr()` is therefore an error.
+In the past, there have been issues where rights management was not handled correctly at the controller level due to the use of an obsolete hardcoded string. To avoid this type of problem, starting with GLPI 12, the use of a hardcoded string, as the first argument (`module`) of `Session::checkRight()`, `Session::checkRightsOr()`,
+`Session::haveRight()`, `Session::haveRightsAnd()`, or `Session::haveRightsOr()`, will be considered an error and must be replaced with the `$rightname` property of the appropriate class.
 
 ```php
 Session::checkRight('computer', READ); // wrong

--- a/extension.neon
+++ b/extension.neon
@@ -32,14 +32,10 @@ services:
             treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
         tags:
             - phpstan.rules.rule
-    -
-        class: PHPStanGlpi\Rules\ForbidHardCodedRightNameRule
-        tags:
-            - phpstan.rules.rule
 
 rules:
     # declared in `services` - PHPStanGlpi\Rules\ForbidDynamicInstantiationRule
-    # declared in `services` - PHPStanGlpi\Rules\ForbidHardCodedRightNameRule
     - PHPStanGlpi\Rules\ForbidExitRule
+    - PHPStanGlpi\Rules\ForbidHardCodedRightNameRule
     - PHPStanGlpi\Rules\ForbidHttpResponseCodeRule
     - PHPStanGlpi\Rules\MissingGlobalVarTypeRule

--- a/extension.neon
+++ b/extension.neon
@@ -39,7 +39,7 @@ services:
 
 rules:
     # declared in `services` - PHPStanGlpi\Rules\ForbidDynamicInstantiationRule
+    # declared in `services` - PHPStanGlpi\Rules\ForbidHardCodedRightNameRule
     - PHPStanGlpi\Rules\ForbidExitRule
     - PHPStanGlpi\Rules\ForbidHttpResponseCodeRule
     - PHPStanGlpi\Rules\MissingGlobalVarTypeRule
-    - PHPStanGlpi\Rules\ForbidHardCodedRightNameRule

--- a/extension.neon
+++ b/extension.neon
@@ -32,9 +32,14 @@ services:
             treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
         tags:
             - phpstan.rules.rule
+    -
+        class: PHPStanGlpi\Rules\ForbidHardCodedRightNameRule
+        tags:
+            - phpstan.rules.rule
 
 rules:
     # declared in `services` - PHPStanGlpi\Rules\ForbidDynamicInstantiationRule
     - PHPStanGlpi\Rules\ForbidExitRule
     - PHPStanGlpi\Rules\ForbidHttpResponseCodeRule
     - PHPStanGlpi\Rules\MissingGlobalVarTypeRule
+    - PHPStanGlpi\Rules\ForbidHardCodedRightNameRule

--- a/src/Rules/ForbidHardCodedRightNameRule.php
+++ b/src/Rules/ForbidHardCodedRightNameRule.php
@@ -85,6 +85,7 @@ final class ForbidHardCodedRightNameRule implements Rule
 
     private function buildErrorMessage(Node\Expr $expr, string $method, Scope $scope): ?string
     {
+        // Caught: literal string passed directly, e.g. Session::checkRight('computer', READ)
         if ($expr instanceof String_) {
             return \sprintf(
                 'Hardcoded string \'%1$s\' used as right name in Session::%2$s(). Use a class static property reference such as %3$s::$rightname instead.',
@@ -94,6 +95,7 @@ final class ForbidHardCodedRightNameRule implements Rule
             );
         }
 
+        // Caught: class constant used as right name, e.g. Session::checkRight(Computer::RIGHTNAME, READ)
         if ($expr instanceof ClassConstFetch && $expr->class instanceof Name && $expr->name instanceof Identifier) {
             $class_name = $expr->class->toString();
             $const_name = $expr->name->toString();
@@ -105,8 +107,9 @@ final class ForbidHardCodedRightNameRule implements Rule
             );
         }
 
+        // Caught: a static property other than $rightname, e.g. Session::checkRight(Computer::$otherProp, READ)
         if ($expr instanceof StaticPropertyFetch && $expr->class instanceof Name && $expr->name instanceof Identifier) {
-            // Correct usage: SomeClass::$rightname — not an error
+            // Correct usage: SomeClass::$rightname — not an error, e.g. Session::checkRight(Computer::$rightname, READ)
             if ($expr->name->name === 'rightname') {
                 return null;
             }
@@ -120,6 +123,8 @@ final class ForbidHardCodedRightNameRule implements Rule
             );
         }
 
+        // Caught: any expression PHPStan resolves to a constant string, e.g.
+        // $right = 'computer'; Session::checkRight($right, READ) or a string concatenation/constant
         $type = $scope->getType($expr);
         $constantStrings = $type->getConstantStrings();
         if (!empty($constantStrings)) {

--- a/src/Rules/ForbidHardCodedRightNameRule.php
+++ b/src/Rules/ForbidHardCodedRightNameRule.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace PHPStanGlpi\Rules;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
@@ -71,73 +69,22 @@ final class ForbidHardCodedRightNameRule implements Rule
 
         $method = $node->name->toString();
 
-        $error_message = $this->buildErrorMessage($first_arg->value, $method, $scope);
-        if ($error_message === null) {
+        if (!($first_arg->value instanceof String_)) {
             return [];
         }
 
+        $string = $first_arg->value;
+
         return [
-            RuleErrorBuilder::message($error_message)
+            RuleErrorBuilder::message(\sprintf(
+                'Hardcoded string \'%1$s\' used as right name in Session::%2$s(). Use a class static property reference such as %3$s::$rightname instead.',
+                $string->value,
+                $method,
+                \ucfirst($string->value),
+            ))
                 ->identifier('glpi.forbidHardCodedRightName')
                 ->build(),
         ];
-    }
-
-    private function buildErrorMessage(Node\Expr $expr, string $method, Scope $scope): ?string
-    {
-        // Caught: literal string passed directly, e.g. Session::checkRight('computer', READ)
-        if ($expr instanceof String_) {
-            return \sprintf(
-                'Hardcoded string \'%1$s\' used as right name in Session::%2$s(). Use a class static property reference such as %3$s::$rightname instead.',
-                $expr->value,
-                $method,
-                \ucfirst($expr->value),
-            );
-        }
-
-        // Caught: class constant used as right name, e.g. Session::checkRight(Computer::RIGHTNAME, READ)
-        if ($expr instanceof ClassConstFetch && $expr->class instanceof Name && $expr->name instanceof Identifier) {
-            $class_name = $expr->class->toString();
-            $const_name = $expr->name->toString();
-            return \sprintf(
-                'Class constant \'%1$s::%2$s\' used as right name in Session::%3$s(). Use %1$s::$rightname instead.',
-                $class_name,
-                $const_name,
-                $method,
-            );
-        }
-
-        // Caught: a static property other than $rightname, e.g. Session::checkRight(Computer::$otherProp, READ)
-        if ($expr instanceof StaticPropertyFetch && $expr->class instanceof Name && $expr->name instanceof Identifier) {
-            // Correct usage: SomeClass::$rightname — not an error, e.g. Session::checkRight(Computer::$rightname, READ)
-            if ($expr->name->name === 'rightname') {
-                return null;
-            }
-            $class_name = $expr->class->toString();
-            $prop_name = $expr->name->name;
-            return \sprintf(
-                'Static property \'%1$s::$%2$s\' used as right name in Session::%3$s(). Use %1$s::$rightname instead.',
-                $class_name,
-                $prop_name,
-                $method,
-            );
-        }
-
-        // Caught: any expression PHPStan resolves to a constant string, e.g.
-        // $right = 'computer'; Session::checkRight($right, READ)
-        $type = $scope->getType($expr);
-        $constantStrings = $type->getConstantStrings();
-        if (!empty($constantStrings)) {
-            $constantStringType = reset($constantStrings);
-            return \sprintf(
-                'Hardcoded string \'%s\' used as right name in Session::%s(). Use a class static property reference such as %s::$rightname instead.',
-                $constantStringType->getValue(),
-                $method,
-                \ucfirst($constantStringType->getValue()),
-            );
-        }
-
-        return null;
     }
 
     private function isSessionRightCheckMethod(StaticCall $node): bool

--- a/src/Rules/ForbidHardCodedRightNameRule.php
+++ b/src/Rules/ForbidHardCodedRightNameRule.php
@@ -14,7 +14,6 @@ use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\Type\Constant\ConstantStringType;
 use PHPStanGlpi\Services\GlpiVersionResolver;
 
 /**
@@ -124,12 +123,14 @@ final class ForbidHardCodedRightNameRule implements Rule
         }
 
         $type = $scope->getType($expr);
-        if ($type instanceof ConstantStringType) {
+        $constantStrings = $type->getConstantStrings();
+        if (!empty($constantStrings)) {
+            $constantStringType = reset($constantStrings);
             return \sprintf(
                 'Hardcoded string \'%s\' used as right name in Session::%s(). Use a class static property reference such as %s::$rightname instead.',
-                $type->getValue(),
+                $constantStringType->getValue(),
                 $method,
-                \ucfirst($type->getValue()),
+                \ucfirst($constantStringType->getValue()),
             );
         }
 

--- a/src/Rules/ForbidHardCodedRightNameRule.php
+++ b/src/Rules/ForbidHardCodedRightNameRule.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace PHPStanGlpi\Rules;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\StaticPropertyFetch;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
@@ -62,13 +64,6 @@ final class ForbidHardCodedRightNameRule implements Rule
             return [];
         }
 
-        // Only report if the argument value is a hardcoded string literal
-        if (!($first_arg->value instanceof String_)) {
-            return [];
-        }
-
-        $string_value = $first_arg->value->value;
-
         // `isSessionRightCheckMethod` already ensures $node->name is an Identifier, but PHPStan cannot infer it
         if (!($node->name instanceof Identifier)) {
             return [];
@@ -76,18 +71,58 @@ final class ForbidHardCodedRightNameRule implements Rule
 
         $method = $node->name->toString();
 
+        $error_message = $this->buildErrorMessage($first_arg->value, $method);
+        if ($error_message === null) {
+            return [];
+        }
+
         return [
-            RuleErrorBuilder::message(
-                \sprintf(
-                    'Hardcoded string \'%s\' used as right name in Session::%s(). Use a class static property reference such as %s::$rightname instead.',
-                    $string_value,
-                    $method,
-                    ucfirst($string_value), // guessed class to use
-                )
-            )
+            RuleErrorBuilder::message($error_message)
                 ->identifier('glpi.forbidHardCodedRightName')
                 ->build(),
         ];
+    }
+
+    private function buildErrorMessage(Node\Expr $expr, string $method): ?string
+    {
+        if ($expr instanceof String_) {
+            return \sprintf(
+                'Hardcoded string \'%s\' used as right name in Session::%s(). Use a class static property reference such as %s::$rightname instead.',
+                $expr->value,
+                $method,
+                \ucfirst($expr->value),
+            );
+        }
+
+        if ($expr instanceof ClassConstFetch && $expr->class instanceof Name && $expr->name instanceof Identifier) {
+            $class_name = $expr->class->toString();
+            $const_name = $expr->name->toString();
+            return \sprintf(
+                'Class constant \'%s::%s\' used as right name in Session::%s(). Use %s::$rightname instead.',
+                $class_name,
+                $const_name,
+                $method,
+                $class_name,
+            );
+        }
+
+        if ($expr instanceof StaticPropertyFetch && $expr->class instanceof Name && $expr->name instanceof Identifier) {
+            // Correct usage: SomeClass::$rightname — not an error
+            if ($expr->name->name === 'rightname') {
+                return null;
+            }
+            $class_name = $expr->class->toString();
+            $prop_name = $expr->name->name;
+            return \sprintf(
+                'Static property \'%s::$%s\' used as right name in Session::%s(). Use %s::$rightname instead.',
+                $class_name,
+                $prop_name,
+                $method,
+                $class_name,
+            );
+        }
+
+        return null;
     }
 
     private function isSessionRightCheckMethod(StaticCall $node): bool

--- a/src/Rules/ForbidHardCodedRightNameRule.php
+++ b/src/Rules/ForbidHardCodedRightNameRule.php
@@ -51,7 +51,7 @@ final class ForbidHardCodedRightNameRule implements Rule
     public function processNode(Node $node, Scope $scope): array
     {
         // bypass rule if glpi version lower than 12
-        if (\version_compare($this->glpiVersionResolver->getGlpiVersion(), '12.0.0-dev', '<=')) {
+        if (\version_compare($this->glpiVersionResolver->getGlpiVersion(), '12.0.0-dev', '<')) {
             return [];
         }
 

--- a/src/Rules/ForbidHardCodedRightNameRule.php
+++ b/src/Rules/ForbidHardCodedRightNameRule.php
@@ -87,7 +87,7 @@ final class ForbidHardCodedRightNameRule implements Rule
     {
         if ($expr instanceof String_) {
             return \sprintf(
-                'Hardcoded string \'%s\' used as right name in Session::%s(). Use a class static property reference such as %s::$rightname instead.',
+                'Hardcoded string \'%1$s\' used as right name in Session::%2$s(). Use a class static property reference such as %3$s::$rightname instead.',
                 $expr->value,
                 $method,
                 \ucfirst($expr->value),
@@ -98,12 +98,10 @@ final class ForbidHardCodedRightNameRule implements Rule
             $class_name = $expr->class->toString();
             $const_name = $expr->name->toString();
             return \sprintf(
-                'Class constant \'%s::%s\' used as right name in Session::%s(). Use %s::$rightname instead.',
+               'Class constant \'%1$s::%2$s\' used as right name in Session::%3$s(). Use %1$s::$rightname instead.',
                 $class_name,
                 $const_name,
                 $method,
-                $class_name,
-            );
         }
 
         if ($expr instanceof StaticPropertyFetch && $expr->class instanceof Name && $expr->name instanceof Identifier) {
@@ -114,11 +112,10 @@ final class ForbidHardCodedRightNameRule implements Rule
             $class_name = $expr->class->toString();
             $prop_name = $expr->name->name;
             return \sprintf(
-                'Static property \'%s::$%s\' used as right name in Session::%s(). Use %s::$rightname instead.',
+                'Static property \'%1$s::%2$s\' used as right name in Session::%3$s(). Use %1$s::$rightname instead.',
                 $class_name,
                 $prop_name,
                 $method,
-                $class_name,
             );
         }
 

--- a/src/Rules/ForbidHardCodedRightNameRule.php
+++ b/src/Rules/ForbidHardCodedRightNameRule.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPStanGlpi\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStanGlpi\Services\GlpiVersionResolver;
+
+/**
+ * @implements Rule<StaticCall>
+ */
+final class ForbidHardCodedRightNameRule implements Rule
+{
+    private const SESSION_CLASS = 'Session';
+
+    private const CHECKED_METHODS = [
+        'checkRight',
+        'checkRightsOr',
+        'haveRight',
+        'haveRightsAnd',
+        'haveRightsOr',
+    ];
+
+    private GlpiVersionResolver $glpiVersionResolver;
+
+    public function __construct(GlpiVersionResolver $glpiVersionResolver)
+    {
+        $this->glpiVersionResolver = $glpiVersionResolver;
+    }
+
+    public function getNodeType(): string
+    {
+        return StaticCall::class;
+    }
+
+    /**
+     * @param StaticCall $node
+     * @param Scope $scope
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // bypass rule if glpi version lower than 12
+        if (\version_compare($this->glpiVersionResolver->getGlpiVersion(), '12.0.0-dev', '<=')) {
+            return [];
+        }
+
+        if (!$this->isSessionRightCheckMethod($node)) {
+            return [];
+        }
+
+        $first_arg = $this->getFirstArgument($node->args);
+        if ($first_arg === null) {
+            return [];
+        }
+
+        // Only report if the argument value is a hardcoded string literal
+        if (!($first_arg->value instanceof String_)) {
+            return [];
+        }
+
+        $string_value = $first_arg->value->value;
+
+        // `isSessionRightCheckMethod` already ensures $node->name is an Identifier, but PHPStan cannot infer it
+        if (!($node->name instanceof Identifier)) {
+            return [];
+        }
+
+        $method = $node->name->toString();
+
+        return [
+            RuleErrorBuilder::message(
+                \sprintf(
+                    'Hardcoded string \'%s\' used as right name in Session::%s(). Use a class static property reference such as %s::$rightname instead.',
+                    $string_value,
+                    $method,
+                    ucfirst($string_value), // guessed class to use
+                )
+            )
+                ->identifier('glpi.forbidHardCodedRightName')
+                ->build(),
+        ];
+    }
+
+    private function isSessionRightCheckMethod(StaticCall $node): bool
+    {
+        // Ignore if the class name is not a static name (e.g. dynamic class - $className::checkRight())
+        if (!($node->class instanceof Name)) {
+            return false;
+        }
+
+        // Only check calls on the Session class
+        if ($node->class->toString() !== self::SESSION_CLASS) {
+            return false;
+        }
+
+        // Ignore if the method name is dynamic (e.g. variable call - Session::$method()) - cannot be analysed by phpstan
+        if (!($node->name instanceof Identifier)) {
+            return false;
+        }
+
+        // Only check calls to the methods listed in CHECKED_METHODS
+        if (!\in_array($node->name->toString(), self::CHECKED_METHODS, true)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<Node\Arg|\PhpParser\Node\VariadicPlaceholder> $args
+     * @return Node\Arg|null
+     */
+    private function getFirstArgument(array $args): ?Node\Arg
+    {
+        // Find the 'module' argument: either the first positional arg or a named 'module' arg
+        // variadic expression cannot be parsed (e.g. `Session::checkRight(...$myvar)` )
+        $first_arg = null;
+        foreach ($args as $arg) {
+            if (!($arg instanceof Node\Arg)) {
+                continue;
+            }
+            // Positional argument (no name): this is the 'module' parameter
+            if ($arg->name === null) {
+                $first_arg = $arg;
+                break;
+            }
+            // Named argument explicitly passed as 'module: ...'
+            if ($arg->name->name === 'module') {
+                $first_arg = $arg;
+                break;
+            }
+        }
+
+        return $first_arg;
+    }
+}

--- a/src/Rules/ForbidHardCodedRightNameRule.php
+++ b/src/Rules/ForbidHardCodedRightNameRule.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\Constant\ConstantStringType;
 use PHPStanGlpi\Services\GlpiVersionResolver;
 
 /**
@@ -71,7 +72,7 @@ final class ForbidHardCodedRightNameRule implements Rule
 
         $method = $node->name->toString();
 
-        $error_message = $this->buildErrorMessage($first_arg->value, $method);
+        $error_message = $this->buildErrorMessage($first_arg->value, $method, $scope);
         if ($error_message === null) {
             return [];
         }
@@ -83,7 +84,7 @@ final class ForbidHardCodedRightNameRule implements Rule
         ];
     }
 
-    private function buildErrorMessage(Node\Expr $expr, string $method): ?string
+    private function buildErrorMessage(Node\Expr $expr, string $method, Scope $scope): ?string
     {
         if ($expr instanceof String_) {
             return \sprintf(
@@ -119,6 +120,16 @@ final class ForbidHardCodedRightNameRule implements Rule
                 $prop_name,
                 $method,
                 $class_name,
+            );
+        }
+
+        $type = $scope->getType($expr);
+        if ($type instanceof ConstantStringType) {
+            return \sprintf(
+                'Hardcoded string \'%s\' used as right name in Session::%s(). Use a class static property reference such as %s::$rightname instead.',
+                $type->getValue(),
+                $method,
+                \ucfirst($type->getValue()),
             );
         }
 

--- a/src/Rules/ForbidHardCodedRightNameRule.php
+++ b/src/Rules/ForbidHardCodedRightNameRule.php
@@ -98,10 +98,11 @@ final class ForbidHardCodedRightNameRule implements Rule
             $class_name = $expr->class->toString();
             $const_name = $expr->name->toString();
             return \sprintf(
-               'Class constant \'%1$s::%2$s\' used as right name in Session::%3$s(). Use %1$s::$rightname instead.',
+                'Class constant \'%1$s::%2$s\' used as right name in Session::%3$s(). Use %1$s::$rightname instead.',
                 $class_name,
                 $const_name,
                 $method,
+            );
         }
 
         if ($expr instanceof StaticPropertyFetch && $expr->class instanceof Name && $expr->name instanceof Identifier) {
@@ -112,7 +113,7 @@ final class ForbidHardCodedRightNameRule implements Rule
             $class_name = $expr->class->toString();
             $prop_name = $expr->name->name;
             return \sprintf(
-                'Static property \'%1$s::%2$s\' used as right name in Session::%3$s(). Use %1$s::$rightname instead.',
+                'Static property \'%1$s::$%2$s\' used as right name in Session::%3$s(). Use %1$s::$rightname instead.',
                 $class_name,
                 $prop_name,
                 $method,

--- a/src/Rules/ForbidHardCodedRightNameRule.php
+++ b/src/Rules/ForbidHardCodedRightNameRule.php
@@ -124,7 +124,7 @@ final class ForbidHardCodedRightNameRule implements Rule
         }
 
         // Caught: any expression PHPStan resolves to a constant string, e.g.
-        // $right = 'computer'; Session::checkRight($right, READ) or a string concatenation/constant
+        // $right = 'computer'; Session::checkRight($right, READ)
         $type = $scope->getType($expr);
         $constantStrings = $type->getConstantStrings();
         if (!empty($constantStrings)) {

--- a/tests/IgnoredGlpiVersion/Rules/ForbidHardCodedRightNameRuleTest.php
+++ b/tests/IgnoredGlpiVersion/Rules/ForbidHardCodedRightNameRuleTest.php
@@ -2,30 +2,26 @@
 
 declare(strict_types=1);
 
-namespace PHPStanGlpi\Tests\Rules;
+namespace PHPStanGlpi\Tests\IgnoredGlpiVersion\Rules;
 
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPStanGlpi\Rules\ForbidHardCodedRightNameRule;
+use PHPStanGlpi\Tests\IgnoredGlpiVersion\TestIgnoredRuleTrait;
 use PHPStanGlpi\Tests\TestTrait;
 
 /**
  * @extends RuleTestCase<ForbidHardCodedRightNameRule>
  */
-class ForbidHardCodedRightNameRuleIgnoredTest extends RuleTestCase
+class ForbidHardCodedRightNameRuleTest extends RuleTestCase
 {
+    use TestIgnoredRuleTrait;
     use TestTrait;
 
     protected function getRule(): Rule
     {
         return new ForbidHardCodedRightNameRule(
-            $this->getGlpiVersionResolver('11.0.0')
+            $this->getGlpiVersionResolver('11.0.0') // should be ignored in GLPI < 12.0.0
         );
     }
-
-    public function testSessionMethods(): void
-    {
-        $this->analyse([__DIR__ . '/../data/ForbidHardCodedRightNameRule/sessionMethods.php'], []);
-    }
-
 }

--- a/tests/Rules/ForbidHardCodedRightNameRuleIgnoredTest.php
+++ b/tests/Rules/ForbidHardCodedRightNameRuleIgnoredTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPStanGlpi\Tests\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStanGlpi\Rules\ForbidHardCodedRightNameRule;
+use PHPStanGlpi\Tests\TestTrait;
+
+/**
+ * @extends RuleTestCase<ForbidHardCodedRightNameRule>
+ */
+class ForbidHardCodedRightNameRuleIgnoredTest extends RuleTestCase
+{
+    use TestTrait;
+
+    protected function getRule(): Rule
+    {
+        return new ForbidHardCodedRightNameRule(
+            $this->getGlpiVersionResolver('11.0.0')
+        );
+    }
+
+    public function testSessionMethods(): void
+    {
+        $this->analyse([__DIR__ . '/../data/ForbidHardCodedRightNameRule/sessionMethods.php'], []);
+    }
+
+}

--- a/tests/Rules/ForbidHardCodedRightNameRuleTest.php
+++ b/tests/Rules/ForbidHardCodedRightNameRuleTest.php
@@ -74,7 +74,7 @@ class ForbidHardCodedRightNameRuleTest extends RuleTestCase
             // variable holding a constant string (inferred via PHPStan type analysis)
             [
                 'Hardcoded string \'logs\' used as right name in Session::checkRight(). Use a class static property reference such as Logs::$rightname instead.',
-                27,
+                25,
             ],
         ]);
     }

--- a/tests/Rules/ForbidHardCodedRightNameRuleTest.php
+++ b/tests/Rules/ForbidHardCodedRightNameRuleTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPStanGlpi\Tests\Rules;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPStanGlpi\Rules\ForbidHardCodedRightNameRule;
+use PHPStanGlpi\Tests\TestTrait;
+
+/**
+ * @extends RuleTestCase<ForbidHardCodedRightNameRule>
+ */
+class ForbidHardCodedRightNameRuleTest extends RuleTestCase
+{
+    use TestTrait;
+
+    protected function getRule(): Rule
+    {
+        return new ForbidHardCodedRightNameRule(
+            $this->getGlpiVersionResolver('12.0.0')
+        );
+    }
+
+    public function testSessionMethods(): void
+    {
+        $this->analyse([__DIR__ . '/../data/ForbidHardCodedRightNameRule/sessionMethods.php'], [
+            // harcoded strings
+            [
+                'Hardcoded string \'hardcoded\' used as right name in Session::checkRight(). Use a class static property reference such as Hardcoded::$rightname instead.',
+                6,
+            ],
+            [
+                'Hardcoded string \'reservation\' used as right name in Session::checkRightsOr(). Use a class static property reference such as Reservation::$rightname instead.',
+                7,
+            ],
+            [
+                'Hardcoded string \'change\' used as right name in Session::haveRight(). Use a class static property reference such as Change::$rightname instead.',
+                8,
+            ],
+            [
+                'Hardcoded string \'ticketvalidation\' used as right name in Session::haveRightsOr(). Use a class static property reference such as Ticketvalidation::$rightname instead.',
+                9,
+            ],
+            [
+                'Hardcoded string \'reservation\' used as right name in Session::haveRightsAnd(). Use a class static property reference such as Reservation::$rightname instead.',
+                10,
+            ],
+            //
+        ]);
+    }
+
+}

--- a/tests/Rules/ForbidHardCodedRightNameRuleTest.php
+++ b/tests/Rules/ForbidHardCodedRightNameRuleTest.php
@@ -26,7 +26,7 @@ class ForbidHardCodedRightNameRuleTest extends RuleTestCase
     public function testSessionMethods(): void
     {
         $this->analyse([__DIR__ . '/../data/ForbidHardCodedRightNameRule/sessionMethods.php'], [
-            // harcoded strings
+            // hardcoded strings
             [
                 'Hardcoded string \'hardcoded\' used as right name in Session::checkRight(). Use a class static property reference such as Hardcoded::$rightname instead.',
                 6,
@@ -47,15 +47,6 @@ class ForbidHardCodedRightNameRuleTest extends RuleTestCase
                 'Hardcoded string \'reservation\' used as right name in Session::haveRightsAnd(). Use a class static property reference such as Reservation::$rightname instead.',
                 10,
             ],
-            // wrong constant / wrong static property
-            [
-                'Class constant \'Ticket::MATRIX_FIELD\' used as right name in Session::checkRight(). Use Ticket::$rightname instead.',
-                13,
-            ],
-            [
-                'Static property \'Glpi\Api::$api_url\' used as right name in Session::checkRight(). Use Glpi\Api::$rightname instead.',
-                14,
-            ],
             // fully qualified Session class
             [
                 'Hardcoded string \'ticket\' used as right name in Session::checkRight(). Use a class static property reference such as Ticket::$rightname instead.',
@@ -70,11 +61,6 @@ class ForbidHardCodedRightNameRuleTest extends RuleTestCase
             [
                 'Hardcoded string \'config\' used as right name in Session::checkRight(). Use a class static property reference such as Config::$rightname instead.',
                 21,
-            ],
-            // variable holding a constant string (inferred via PHPStan type analysis)
-            [
-                'Hardcoded string \'logs\' used as right name in Session::checkRight(). Use a class static property reference such as Logs::$rightname instead.',
-                25,
             ],
         ]);
     }

--- a/tests/Rules/ForbidHardCodedRightNameRuleTest.php
+++ b/tests/Rules/ForbidHardCodedRightNameRuleTest.php
@@ -47,7 +47,30 @@ class ForbidHardCodedRightNameRuleTest extends RuleTestCase
                 'Hardcoded string \'reservation\' used as right name in Session::haveRightsAnd(). Use a class static property reference such as Reservation::$rightname instead.',
                 10,
             ],
-            //
+            // wrong constant / wrong static property
+            [
+                'Class constant \'Ticket::MATRIX_FIELD\' used as right name in Session::checkRight(). Use Ticket::$rightname instead.',
+                13,
+            ],
+            [
+                'Static property \'Glpi\Api::$api_url\' used as right name in Session::checkRight(). Use Glpi\Api::$rightname instead.',
+                14,
+            ],
+            // fully qualified Session class
+            [
+                'Hardcoded string \'ticket\' used as right name in Session::checkRight(). Use a class static property reference such as Ticket::$rightname instead.',
+                17,
+            ],
+            // named argument for 'module'
+            [
+                'Hardcoded string \'config\' used as right name in Session::checkRight(). Use a class static property reference such as Config::$rightname instead.',
+                20,
+            ],
+            // named argument for 'module', reversed order
+            [
+                'Hardcoded string \'config\' used as right name in Session::checkRight(). Use a class static property reference such as Config::$rightname instead.',
+                21,
+            ],
         ]);
     }
 

--- a/tests/Rules/ForbidHardCodedRightNameRuleTest.php
+++ b/tests/Rules/ForbidHardCodedRightNameRuleTest.php
@@ -50,17 +50,17 @@ class ForbidHardCodedRightNameRuleTest extends RuleTestCase
             // fully qualified Session class
             [
                 'Hardcoded string \'ticket\' used as right name in Session::checkRight(). Use a class static property reference such as Ticket::$rightname instead.',
-                17,
+                13,
             ],
             // named argument for 'module'
             [
                 'Hardcoded string \'config\' used as right name in Session::checkRight(). Use a class static property reference such as Config::$rightname instead.',
-                20,
+                16,
             ],
             // named argument for 'module', reversed order
             [
                 'Hardcoded string \'config\' used as right name in Session::checkRight(). Use a class static property reference such as Config::$rightname instead.',
-                21,
+                17,
             ],
         ]);
     }

--- a/tests/Rules/ForbidHardCodedRightNameRuleTest.php
+++ b/tests/Rules/ForbidHardCodedRightNameRuleTest.php
@@ -71,6 +71,11 @@ class ForbidHardCodedRightNameRuleTest extends RuleTestCase
                 'Hardcoded string \'config\' used as right name in Session::checkRight(). Use a class static property reference such as Config::$rightname instead.',
                 21,
             ],
+            // variable holding a constant string (inferred via PHPStan type analysis)
+            [
+                'Hardcoded string \'logs\' used as right name in Session::checkRight(). Use a class static property reference such as Logs::$rightname instead.',
+                27,
+            ],
         ]);
     }
 

--- a/tests/data/ForbidHardCodedRightNameRule/sessionMethods.php
+++ b/tests/data/ForbidHardCodedRightNameRule/sessionMethods.php
@@ -1,0 +1,29 @@
+<?php
+
+// --- will be caught - reported in test ---
+
+    // harcoded strings
+    Session::checkRight('hardcoded', READ);
+    Session::checkRightsOr('reservation', [CREATE, UPDATE, DELETE, PURGE]);
+    Session::haveRight('change', UPDATE);
+    Session::haveRightsOr('ticketvalidation', TicketValidation::getValidateRights());
+    Session::haveRightsAnd('reservation', [CREATE, UPDATE, DELETE, PURGE]);
+
+    // wrong variable
+    Session::checkRight(Ticket::MATRIX_FIELD, READ); // constant
+    Session::checkRight(\Glpi\Api::$api_url, READ); // static variable but wrong one
+
+
+// --- won't be caught but should ---
+
+    // phpstan cannot analyse this, it seems, but should be caught - @todo check if possible
+    $variable = 'logs';
+    Session::checkRight($variable, UPDATE);
+
+// --- won't be caught - correct usage ---
+
+Session::checkRight(Ticket::$rightname, READ);
+Session::checkRightsOr(\Glpi\Socket::$rightname, [CREATE, UPDATE, DELETE, PURGE]);
+Session::haveRight(Ticket::$rightname, UPDATE);
+Session::haveRightsOr(Ticket::$rightname, TicketValidation::getValidateRights());
+Session::haveRightsAnd(Ticket::$rightname, [CREATE, UPDATE, DELETE, PURGE]);

--- a/tests/data/ForbidHardCodedRightNameRule/sessionMethods.php
+++ b/tests/data/ForbidHardCodedRightNameRule/sessionMethods.php
@@ -9,9 +9,16 @@
     Session::haveRightsOr('ticketvalidation', TicketValidation::getValidateRights());
     Session::haveRightsAnd('reservation', [CREATE, UPDATE, DELETE, PURGE]);
 
-    // wrong variable
+    // wrong constant / static property
     Session::checkRight(Ticket::MATRIX_FIELD, READ); // constant
     Session::checkRight(\Glpi\Api::$api_url, READ); // static variable but wrong one
+
+    // fully qualified Session class is equivalent
+    \Session::checkRight('ticket', READ);
+
+    // named argument for 'module'
+    Session::checkRight(right: READ, module: 'config');
+    Session::checkRight(module: 'config', right: READ);
 
 
 // --- won't be caught but should ---
@@ -27,3 +34,10 @@ Session::checkRightsOr(\Glpi\Socket::$rightname, [CREATE, UPDATE, DELETE, PURGE]
 Session::haveRight(Ticket::$rightname, UPDATE);
 Session::haveRightsOr(Ticket::$rightname, TicketValidation::getValidateRights());
 Session::haveRightsAnd(Ticket::$rightname, [CREATE, UPDATE, DELETE, PURGE]);
+
+// --- won't be caught - not applicable ---
+
+Foo::checkRight('not_session', READ); // not the Session class
+Session::login('not_right_method', READ); // not in CHECKED_METHODS
+Session::checkRight(...$args); // variadic — no positional 'module' arg
+

--- a/tests/data/ForbidHardCodedRightNameRule/sessionMethods.php
+++ b/tests/data/ForbidHardCodedRightNameRule/sessionMethods.php
@@ -9,20 +9,12 @@
     Session::haveRightsOr('ticketvalidation', TicketValidation::getValidateRights());
     Session::haveRightsAnd('reservation', [CREATE, UPDATE, DELETE, PURGE]);
 
-    // wrong constant / static property
-    Session::checkRight(Ticket::MATRIX_FIELD, READ); // constant
-    Session::checkRight(\Glpi\Api::$api_url, READ); // static variable but wrong one
-
     // fully qualified Session class is equivalent
     \Session::checkRight('ticket', READ);
 
     // named argument for 'module'
     Session::checkRight(right: READ, module: 'config');
     Session::checkRight(module: 'config', right: READ);
-
-    // intermediate variable used
-    $variable = 'logs';
-    Session::checkRight($variable, UPDATE);
 
 // --- won't be caught
 
@@ -34,7 +26,15 @@
     Session::haveRightsOr(Ticket::$rightname, TicketValidation::getValidateRights());
     Session::haveRightsAnd(Ticket::$rightname, [CREATE, UPDATE, DELETE, PURGE]);
 
-    // not applicable ---
+    // not applicable
+
+    // wrong constant / static property — not caught, rule only checks literal strings
+    Session::checkRight(Ticket::MATRIX_FIELD, READ);
+    Session::checkRight(\Glpi\Api::$api_url, READ);
+
+    // intermediate variable — not caught, rule does not resolve variable types
+    $variable = 'logs';
+    Session::checkRight($variable, UPDATE);
 
     Foo::checkRight('not_session', READ); // not the Session class
     Session::login('not_right_method', READ); // not in CHECKED_METHODS

--- a/tests/data/ForbidHardCodedRightNameRule/sessionMethods.php
+++ b/tests/data/ForbidHardCodedRightNameRule/sessionMethods.php
@@ -21,11 +21,10 @@
     Session::checkRight(module: 'config', right: READ);
 
 
-// --- won't be caught but should ---
+// --- will be caught - variable holding a constant string ---
 
-    // phpstan cannot analyse this, it seems, but should be caught - @todo check if possible
     $variable = 'logs';
-    Session::checkRight($variable, UPDATE);
+    Session::checkRight($variable, UPDATE); // reported: PHPStan infers ConstantStringType
 
 // --- won't be caught - correct usage ---
 

--- a/tests/data/ForbidHardCodedRightNameRule/sessionMethods.php
+++ b/tests/data/ForbidHardCodedRightNameRule/sessionMethods.php
@@ -20,23 +20,23 @@
     Session::checkRight(right: READ, module: 'config');
     Session::checkRight(module: 'config', right: READ);
 
-
-// --- will be caught - variable holding a constant string ---
-
+    // intermediate variable used
     $variable = 'logs';
-    Session::checkRight($variable, UPDATE); // reported: PHPStan infers ConstantStringType
+    Session::checkRight($variable, UPDATE);
 
-// --- won't be caught - correct usage ---
+// --- won't be caught
 
-Session::checkRight(Ticket::$rightname, READ);
-Session::checkRightsOr(\Glpi\Socket::$rightname, [CREATE, UPDATE, DELETE, PURGE]);
-Session::haveRight(Ticket::$rightname, UPDATE);
-Session::haveRightsOr(Ticket::$rightname, TicketValidation::getValidateRights());
-Session::haveRightsAnd(Ticket::$rightname, [CREATE, UPDATE, DELETE, PURGE]);
+    // correct usage
 
-// --- won't be caught - not applicable ---
+    Session::checkRight(Ticket::$rightname, READ);
+    Session::checkRightsOr(\Glpi\Socket::$rightname, [CREATE, UPDATE, DELETE, PURGE]);
+    Session::haveRight(Ticket::$rightname, UPDATE);
+    Session::haveRightsOr(Ticket::$rightname, TicketValidation::getValidateRights());
+    Session::haveRightsAnd(Ticket::$rightname, [CREATE, UPDATE, DELETE, PURGE]);
 
-Foo::checkRight('not_session', READ); // not the Session class
-Session::login('not_right_method', READ); // not in CHECKED_METHODS
-Session::checkRight(...$args); // variadic — no positional 'module' arg
+    // not applicable ---
+
+    Foo::checkRight('not_session', READ); // not the Session class
+    Session::login('not_right_method', READ); // not in CHECKED_METHODS
+    Session::checkRight(...$args); // variadic — no positional 'module' arg
 


### PR DESCRIPTION
A big part was generated using a coding agent.
I reviewed the code.
Tested on a glpi (main branch).

Not tested on a 11/bugfixes branch (rule should not apply).