### PR TITLE
Do not require latest production dependencies automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
     schedule:
       interval: "monthly"
     versioning-strategy: "increase"
+    allow:
+      - dependency-type: "development"
     groups:
       dev-dependencies:
         dependency-type: "development"


### PR DESCRIPTION
Upgrading production dependencies may prevent the current lib to be installed in older GLPI versions.