### PR TITLE
Drop GLPI 10.0 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { php-version: "7.4" }
+          - { php-version: "8.2" }
           - { php-version: "8.4" }
     steps:
       - name: "Checkout"

--- a/README.md
+++ b/README.md
@@ -33,16 +33,9 @@ parameters:
         - ../../inc
         - ../../src
 
-    # for GLPI 11.x the following configuration entries must be used
     bootstrapFiles:
         - ../../stubs/glpi_constants.php
         - ../../vendor/autoload.php
-
-    # for GLPI 10.x the following configuration entries must be used
-    bootstrapFiles:
-        - ../../inc/based_config.php
-    stubFiles:
-        - ../../stubs/glpi_constants.php
 ```
 
 The GLPI path and version should be detected automatically, but you can specify them in the `parameters` section of your PHPStan configuration:

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "MIT"
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.2",
         "phpstan/phpstan": "^2.1",
         "symfony/polyfill-php80": "^1.37"
     },
@@ -19,7 +19,7 @@
     "config": {
         "optimize-autoloader": true,
         "platform": {
-            "php": "7.4.99"
+            "php": "8.2.99"
         },
         "sort-packages": true
     },

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "friendsofphp/php-cs-fixer": "^3.95",
         "php-parallel-lint/php-parallel-lint": "^1.4",
         "phpstan/phpstan-phpunit": "^2.0",
-        "phpunit/phpunit": "^9.6"
+        "phpunit/phpunit": "^11.5"
     },
     "config": {
         "optimize-autoloader": true,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: "php:7.4-cli"
+    image: "php:8.2-cli"
     user: "${UID:-1000}:${GID:-1000}"
     working_dir: /app
     volumes:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,14 +4,12 @@
      xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
      bootstrap="tests/bootstrap.php"
      colors="true"
-     backupGlobals="false"
-     backupStaticAttributes="false"
      beStrictAboutChangesToGlobalState="true"
      beStrictAboutOutputDuringTests="true"
      beStrictAboutTestsThatDoNotTestAnything="true"
-     beStrictAboutTodoAnnotatedTests="true"
      failOnRisky="true"
      failOnWarning="true"
+     displayDetailsOnAllIssues="true"
 >
     <testsuites>
         <testsuite name="PHPStan GLPI rules">

--- a/tests/Analyser/CommonDBTMCanInputParamOutTypeResolverTest.php
+++ b/tests/Analyser/CommonDBTMCanInputParamOutTypeResolverTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PHPStanGlpi\Tests\Analyser;
 
 use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class CommonDBTMCanInputParamOutTypeResolverTest extends TypeInferenceTestCase
 {
@@ -18,8 +19,8 @@ class CommonDBTMCanInputParamOutTypeResolverTest extends TypeInferenceTestCase
 
     /**
      * @param mixed ...$args
-     * @dataProvider dataFileAsserts
      */
+    #[DataProvider('dataFileAsserts')]
     public function testFileAsserts(
         string $assertType,
         string $file,

--- a/tests/Analyser/GlobalTypeResolverForGlpi10Test.php
+++ b/tests/Analyser/GlobalTypeResolverForGlpi10Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PHPStanGlpi\Tests\Analyser;
 
 use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class GlobalTypeResolverForGlpi10Test extends TypeInferenceTestCase
 {
@@ -21,8 +22,8 @@ class GlobalTypeResolverForGlpi10Test extends TypeInferenceTestCase
 
     /**
      * @param mixed ...$args
-     * @dataProvider dataFileAsserts
      */
+    #[DataProvider('dataFileAsserts')]
     public function testFileAsserts(
         string $assertType,
         string $file,

--- a/tests/Analyser/GlobalTypeResolverForGlpi11Test.php
+++ b/tests/Analyser/GlobalTypeResolverForGlpi11Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PHPStanGlpi\Tests\Analyser;
 
 use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class GlobalTypeResolverForGlpi11Test extends TypeInferenceTestCase
 {
@@ -21,8 +22,8 @@ class GlobalTypeResolverForGlpi11Test extends TypeInferenceTestCase
 
     /**
      * @param mixed ...$args
-     * @dataProvider dataFileAsserts
      */
+    #[DataProvider('dataFileAsserts')]
     public function testFileAsserts(
         string $assertType,
         string $file,

--- a/tests/Rules/ForbidDynamicInstantiationRulePhpDocAsCertainTest.php
+++ b/tests/Rules/ForbidDynamicInstantiationRulePhpDocAsCertainTest.php
@@ -81,9 +81,6 @@ class ForbidDynamicInstantiationRulePhpDocAsCertainTest extends RuleTestCase
         ]);
     }
 
-    /**
-     * @requires PHP >= 8.0
-     */
     public function testUnionType(): void
     {
         $this->analyse([__DIR__ . '/../data/ForbidDynamicInstantiationRule/union-type.php'], [

--- a/tests/Rules/ForbidDynamicInstantiationRulePhpDocAsUncertainTest.php
+++ b/tests/Rules/ForbidDynamicInstantiationRulePhpDocAsUncertainTest.php
@@ -88,9 +88,6 @@ class ForbidDynamicInstantiationRulePhpDocAsUncertainTest extends RuleTestCase
         ]);
     }
 
-    /**
-     * @requires PHP >= 8.0
-     */
     public function testUnionType(): void
     {
         $this->analyse([__DIR__ . '/../data/ForbidDynamicInstantiationRule/union-type.php'], [


### PR DESCRIPTION
Since we will not add new rules for GLPI 10.0, we can drop its support for the next version of this extension, to be able to use PHP 8.2+ features.

If a bug is found for the only existing rule for GLPI 10.0 (`MissingGlobalVarTypeRule`), we would still be able to release a bugfix version based on the 1.2.x version.

I also upgraded PHPUnit to a most recent version.