### PR TITLE
Drop useless `symfony/polyfill-php80` polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,7 @@
     ],
     "require": {
         "php": ">=8.2",
-        "phpstan/phpstan": "^2.1",
-        "symfony/polyfill-php80": "^1.37"
+        "phpstan/phpstan": "^2.1"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.95",


### PR DESCRIPTION
It follows #29 .

Since PHP >= 8.2 is required, this polyfill is now useless.